### PR TITLE
Fixing Layer Panel Layout for Mobile or Small Screen Issue

### DIFF
--- a/src/lib/AlphaModal.svelte
+++ b/src/lib/AlphaModal.svelte
@@ -114,7 +114,7 @@
 		display: flex;
 		justify-content: center;
 		align-items: center;
-		z-index: 1000;
+		z-index: 10000;
 		backdrop-filter: blur(2px);
 	}
 

--- a/src/lib/components/LayerPanel.svelte
+++ b/src/lib/components/LayerPanel.svelte
@@ -84,3 +84,99 @@
 		</div>
 	{/if}
 {/each}
+
+<style>
+	.layer-section {
+		margin-bottom: 1.5rem;
+		padding-bottom: 1rem;
+		border-bottom: 1px solid #e2e8f0;
+	}
+
+	.layer-heading {
+		margin: 0 0 0.75rem 0;
+		font-size: 1rem;
+		font-weight: 600;
+		color: #374151;
+	}
+
+	.network-types {
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+		margin-bottom: 1rem;
+	}
+
+	.network-types label {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		font-size: 0.875rem;
+		color: #4b5563;
+		cursor: pointer;
+	}
+
+	.network-types input[type="checkbox"] {
+		margin: 0;
+	}
+
+	.color-section {
+		margin-bottom: 1rem;
+	}
+
+	.color-label {
+		display: block;
+		margin-bottom: 0.5rem;
+		font-size: 0.875rem;
+		font-weight: 500;
+		color: #374151;
+	}
+
+	.color-dropdown {
+		width: 100%;
+		padding: 0.5rem;
+		border: 1px solid #d1d5db;
+		border-radius: 0.375rem;
+		font-size: 0.875rem;
+		background-color: white;
+	}
+
+	.color-dropdown:focus {
+		outline: none;
+		border-color: #3b82f6;
+		box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+	}
+
+	.option {
+		margin-bottom: 1rem;
+		padding-bottom: 0.75rem;
+		border-bottom: 1px solid #f3f4f6;
+	}
+
+	.option:last-child {
+		border-bottom: none;
+		margin-bottom: 0;
+		padding-bottom: 0;
+	}
+
+	.option label {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		font-size: 0.875rem;
+		color: #374151;
+		cursor: pointer;
+		margin-bottom: 0.5rem;
+	}
+
+	.option input[type="checkbox"] {
+		margin: 0;
+	}
+
+	.legend-container {
+		margin-top: 0.75rem;
+		padding: 0.75rem;
+		background-color: #f9fafb;
+		border-radius: 0.375rem;
+		border: 1px solid #e5e7eb;
+	}
+</style>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -297,6 +297,21 @@
 					ALPHA
 				</button>
 			</div>
+
+			<!-- Mobile alpha button -->
+			<div class="mobile-alpha-button">
+				<button
+					class="alpha-mobile"
+					onclick={() => {
+						// Access parent component's alpha modal function
+						window.dispatchEvent(new CustomEvent('show-alpha-modal'));
+					}}
+					aria-label="Show alpha information"
+					type="button"
+				>
+					ALPHA
+				</button>
+			</div>
 		</MapLibre>
 	</div>
 
@@ -374,13 +389,38 @@
 			height: 100dvh !important;
 		}
 
-		/* Hide sidebar on mobile and show original dropdown behavior */
+		/* Show sidebar as bottom panel on mobile */
 		.app-container {
 			flex-direction: column;
 		}
 
+		.map-container {
+			height: 60vh; /* Map takes 60% of viewport height */
+		}
+
 		.layers-sidebar {
-			display: none;
+			position: fixed;
+			bottom: 0;
+			left: 0;
+			right: 0;
+			width: 100%;
+			height: 40vh; /* Panel takes 40% of viewport height */
+			border-left: none;
+			border-top: 1px solid #e2e8f0;
+			box-shadow: 0 -4px 12px rgba(0, 0, 0, 0.15);
+			z-index: 1000;
+		}
+
+		.sidebar-content {
+			padding: 0.75rem;
+		}
+
+		.sidebar-header {
+			padding: 0.75rem 1rem;
+		}
+
+		.sidebar-header h3 {
+			font-size: 1rem;
 		}
 	}
 
@@ -388,7 +428,7 @@
 		position: absolute;
 		bottom: 35px;
 		right: 20px;
-		z-index: 1000;
+		z-index: 9999;
 		display: none;
 	}
 
@@ -416,4 +456,6 @@
 			display: block;
 		}
 	}
+
+
 </style>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -21,7 +21,6 @@
 
 	// State: initial values and types
 	let showBasemapPanel = $state(false);
-	let showLayersPanel = $state(false);
 	let currentBasemap = $state('gray');
 	let currentNetworkType = $state(''); // No network selected by default
 	let currentNetworkColor = $state('bicycle');

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -16,11 +16,12 @@
 	import { LAYERS, MAP_CONFIG } from '$lib/config/layers.js';
 	import MapControlPanel from '$lib/components/MapControlPanel.svelte';
 	import MapLayers from '$lib/components/MapLayers.svelte';
+	import LayerPanel from '$lib/components/LayerPanel.svelte';
 	import Geocoder from '$lib/components/Geocoder.svelte';
 
 	// State: initial values and types
 	let showBasemapPanel = $state(false);
-	let showLayersPanel = $state(true);
+	let showLayersPanel = $state(false);
 	let currentBasemap = $state('gray');
 	let currentNetworkType = $state(''); // No network selected by default
 	let currentNetworkColor = $state('bicycle');
@@ -243,75 +244,123 @@
 	<PMTilesProtocol />
 {/if}
 
-<MapLibre
-	class="h-full max-sm:h-screen mobile-map-height"
-	style={currentBasemapStyle}
-	center={center}
-	zoom={zoom}
-	bind:map={mapInstance}
-	onmoveend={handleMoveEnd}
-	onzoomend={handleZoomEnd}
->
-	<NavigationControl position="top-left" />
-	<FullScreenControl position="top-left" />
-	<GeolocateControl position="top-left" />
-	<ScaleControl position="bottom-left" unit="metric" maxWidth={200}/>
-
-	<!-- Basemap Control -->
-	<CustomControl position="top-left">
-		<MapControlPanel 
-			controlType="basemap"
-			showPanel={showBasemapPanel}
-			onToggle={() => togglePanel('basemap')}
-			title="Change basemap"
-			position="left"
-			currentBasemap={currentBasemap}
-			onBasemapSelect={selectBasemap}
-		/>
-	</CustomControl>
-
-	<!-- Geocoder with custom positioning -->
-	<div class="custom-geocoder-position">
-		<Geocoder map={mapInstance || null} apiKey={import.meta.env.VITE_MAPBOX_ACCESS_TOKEN} />
-	</div>
-
-	<!-- Layers Control -->
-	<CustomControl position="top-right">
-		<MapControlPanel 
-			controlType="layers"
-			showPanel={showLayersPanel}
-			onToggle={() => togglePanel('layers')}
-			title="Layers"
-			position="right"
-			layerStates={layerStates}
-			currentNetworkType={currentNetworkType}
-			currentNetworkColor={currentNetworkColor}
-			onToggleLayer={toggleLayer}
-			onNetworkTypeChange={setNetworkType}
-			onNetworkColorChange={setNetworkColor}
-		/>
-	</CustomControl>
-
-	<!-- Dynamic Layers -->
-	<MapLayers activeLayers={layerStates} networkType={currentNetworkType} networkColor={currentNetworkColor} />
-	
-	<!-- Mobile-only floating Alpha button -->
-	<div class="mobile-alpha-button">
-		<button
-			class="alpha-mobile"
-			onclick={() => {
-				// Access parent component's alpha modal function
-				window.dispatchEvent(new CustomEvent('show-alpha-modal'));
-			}}
-			aria-label="Show alpha information"
-			type="button"
+<!-- Main container with sidebar layout -->
+<div class="app-container">
+	<!-- Map container -->
+	<div class="map-container">
+		<MapLibre
+			class="h-full max-sm:h-screen mobile-map-height"
+			style={currentBasemapStyle}
+			center={center}
+			zoom={zoom}
+			bind:map={mapInstance}
+			onmoveend={handleMoveEnd}
+			onzoomend={handleZoomEnd}
 		>
-			ALPHA
-		</button>
+			<NavigationControl position="top-left" />
+			<FullScreenControl position="top-left" />
+			<GeolocateControl position="top-left" />
+			<ScaleControl position="bottom-left" unit="metric" maxWidth={200}/>
+
+			<!-- Basemap Control -->
+			<CustomControl position="top-left">
+				<MapControlPanel 
+					controlType="basemap"
+					showPanel={showBasemapPanel}
+					onToggle={() => togglePanel('basemap')}
+					title="Change basemap"
+					position="left"
+					currentBasemap={currentBasemap}
+					onBasemapSelect={selectBasemap}
+				/>
+			</CustomControl>
+
+			<!-- Geocoder with custom positioning -->
+			<div class="custom-geocoder-position">
+				<Geocoder map={mapInstance || null} apiKey={import.meta.env.VITE_MAPBOX_ACCESS_TOKEN} />
+			</div>
+
+			<!-- Dynamic Layers -->
+			<MapLayers activeLayers={layerStates} networkType={currentNetworkType} networkColor={currentNetworkColor} />
+			
+			<!-- Mobile-only floating Alpha button -->
+			<div class="mobile-alpha-button">
+				<button
+					class="alpha-mobile"
+					onclick={() => {
+						// Access parent component's alpha modal function
+						window.dispatchEvent(new CustomEvent('show-alpha-modal'));
+					}}
+					aria-label="Show alpha information"
+					type="button"
+				>
+					ALPHA
+				</button>
+			</div>
+		</MapLibre>
 	</div>
-</MapLibre>
+
+	<!-- Right sidebar for layers -->
+	<div class="layers-sidebar">
+		<div class="sidebar-header">
+			<h3>Layers</h3>
+		</div>
+		<div class="sidebar-content">
+			<LayerPanel
+				layerStates={layerStates}
+				currentNetworkType={currentNetworkType}
+				currentNetworkColor={currentNetworkColor}
+				onToggleLayer={toggleLayer}
+				onNetworkTypeChange={setNetworkType}
+				onNetworkColorChange={setNetworkColor}
+			/>
+		</div>
+	</div>
+</div>
 
 <style>
+	/* App layout with sidebar */
+	.app-container {
+		display: flex;
+		height: 100vh;
+		width: 100vw;
+	}
+
+	.map-container {
+		flex: 1;
+		height: 100vh;
+		overflow: hidden;
+	}
+
+	.layers-sidebar {
+		width: 320px;
+		height: 100vh;
+		background-color: white;
+		border-left: 1px solid #e2e8f0;
+		display: flex;
+		flex-direction: column;
+		box-shadow: -2px 0 8px rgba(0, 0, 0, 0.1);
+	}
+
+	.sidebar-header {
+		padding: 1rem;
+		border-bottom: 1px solid #e2e8f0;
+		background-color: #f8fafc;
+	}
+
+	.sidebar-header h3 {
+		margin: 0;
+		font-size: 1.125rem;
+		font-weight: 600;
+		color: #1e293b;
+	}
+
+	.sidebar-content {
+		flex: 1;
+		padding: 1rem;
+		overflow-y: auto;
+	}
+
 	:global(.custom-geocoder-position) {
 		position: absolute;
 		top: 10px;
@@ -324,8 +373,16 @@
 		:global(.mobile-map-height) {
 			height: 100dvh !important;
 		}
-	}
 
+		/* Hide sidebar on mobile and show original dropdown behavior */
+		.app-container {
+			flex-direction: column;
+		}
+
+		.layers-sidebar {
+			display: none;
+		}
+	}
 
 	.mobile-alpha-button {
 		position: absolute;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -322,7 +322,7 @@
 	/* App layout with sidebar */
 	.app-container {
 		display: flex;
-		height: 100%; /* Use 100% to fill the main content area, not full viewport */
+		height: 100%; /* Use 100% to fill the full viewport height */
 		width: 100vw;
 	}
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -256,6 +256,7 @@
 			bind:map={mapInstance}
 			onmoveend={handleMoveEnd}
 			onzoomend={handleZoomEnd}
+			attributionControl={true}
 		>
 			<NavigationControl position="top-left" />
 			<FullScreenControl position="top-left" />
@@ -297,21 +298,6 @@
 					ALPHA
 				</button>
 			</div>
-
-			<!-- Mobile alpha button -->
-			<div class="mobile-alpha-button">
-				<button
-					class="alpha-mobile"
-					onclick={() => {
-						// Access parent component's alpha modal function
-						window.dispatchEvent(new CustomEvent('show-alpha-modal'));
-					}}
-					aria-label="Show alpha information"
-					type="button"
-				>
-					ALPHA
-				</button>
-			</div>
 		</MapLibre>
 	</div>
 
@@ -337,19 +323,18 @@
 	/* App layout with sidebar */
 	.app-container {
 		display: flex;
-		height: 100vh;
+		height: 100%; /* Use 100% to fill the main content area, not full viewport */
 		width: 100vw;
 	}
 
 	.map-container {
 		flex: 1;
-		height: 100vh;
-		overflow: hidden;
+		height: 100%; /* Use 100% instead of 100vh to fill the available main content area */
 	}
 
 	.layers-sidebar {
 		width: 320px;
-		height: 100vh;
+		height: 100%; /* Match the main content area height */
 		background-color: white;
 		border-left: 1px solid #e2e8f0;
 		display: flex;
@@ -396,6 +381,15 @@
 
 		.map-container {
 			height: 60vh; /* Map takes 60% of viewport height */
+		}
+
+		/* Adjust map controls positioning on mobile to avoid overlap with bottom panel */
+		:global(.maplibregl-ctrl-bottom-left) {
+			bottom: 40vh !important;
+		}
+
+		:global(.maplibregl-ctrl-bottom-right) {
+			bottom: 40vh !important;
 		}
 
 		.layers-sidebar {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -328,7 +328,7 @@
 
 	.map-container {
 		flex: 1;
-		height: 100%; /* Use 100% instead of 100vh to fill the available main content area */
+		height: 100%; /* Fill available height within the flex container */
 	}
 
 	.layers-sidebar {


### PR DESCRIPTION
Logged the mobile screen layer panel issue here (#105).

Changes made:
Fixed the layout of the layer panel on small screens, the panel now occupies 40% of the screen height, while the remaining 60% is reserved for the map.
This ensures the panel doesn’t block key data on the map, while still providing users with immediate access to layer controls upon landing.

Tested on:
- Desktop browser (widescreen)
- Mobile view via browser dev tools

On the wide screen:
<img width="3438" height="1957" alt="image" src="https://github.com/user-attachments/assets/3b77d3cd-ac8a-4394-85d5-db2fa718ad78" />

On small screen:
<img width="591" height="1273" alt="image" src="https://github.com/user-attachments/assets/26eda2a4-2a1c-46f3-bba8-0388947f18a1" />



